### PR TITLE
Add print buffer functions

### DIFF
--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <fstream>
 #include <typeindex>
 #include <string>
 #include <vector>
@@ -99,6 +100,12 @@ protected:
     void LoadNetwork();
 
     virtual void Infer();
+
+    template<InferenceEngine::Precision::ePrecision PRC>
+    void PrintBuffer(std::ofstream &os, InferenceEngine::Blob::Ptr blob);
+
+    void PrintBuffer(std::string &filename, const void* expectedBuffer, std::size_t size, const InferenceEngine::Precision &prc);
+    void PrintBuffer(std::string &filename, InferenceEngine::Blob::Ptr blob, const InferenceEngine::Precision &prc);
 
     TargetDevice targetDevice;
     std::shared_ptr<ngraph::Function> function;


### PR DESCRIPTION
Example usage:
mkdir /home/yanglei/flex-plaidml/openvino/cache/
FLEX_BUFFER_CACHE=/home/yanglei/flex-plaidml/openvino/cache/ PLAIDML_DEVICE=llvm_cpu.0 PLAIDML_TARGET=llvm_cpu PlaidMLFuncTests -- --gtest_filter=\*GrnCheck1\*

This will dump all input and output buffers to your cache directory