### PR TITLE
reverseSequence op in shared 

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reverse_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reverse_sequence.cpp
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "single_layer_tests/reverse_sequence.hpp"
-
-#include <memory>
-#include <string>
 #include <tuple>
+#include <string>
 #include <vector>
+#include <memory>
 
 #include "common_test_utils/common_utils.hpp"
 #include "functional_test_utils/precision_utils.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
+
+#include "single_layer_tests/reverse_sequence.hpp"
 
 namespace LayerTestsDefinitions {
 std::string ReverseSequenceLayerTest::getTestCaseName(const testing::TestParamInfo<ReverseSequenceParamsTuple> &obj) {
@@ -60,6 +60,8 @@ void ReverseSequenceLayerTest::SetUp() {
     function = std::make_shared<ngraph::Function>(results, paramsIn, "ReverseSequence");
 }
 
-TEST_P(ReverseSequenceLayerTest, CompareWithRefs) { Run(); };
+TEST_P(ReverseSequenceLayerTest, CompareWithRefs) {
+    Run();
+};
 
-}  // namespace LayerTestsDefinitions
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reverse_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reverse_sequence.cpp
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <tuple>
-#include <string>
-#include <vector>
+#include "single_layer_tests/reverse_sequence.hpp"
+
 #include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include "common_test_utils/common_utils.hpp"
 #include "functional_test_utils/precision_utils.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
-
-#include "single_layer_tests/reverse_sequence.hpp"
 
 namespace LayerTestsDefinitions {
 std::string ReverseSequenceLayerTest::getTestCaseName(const testing::TestParamInfo<ReverseSequenceParamsTuple> &obj) {
@@ -49,8 +49,8 @@ void ReverseSequenceLayerTest::SetUp() {
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShape});
 
-    auto secondPrc = ngraph::element::Type_t::i32; //according to the specification
-    auto secondaryInput = ngraph::builder::makeInputLayer(secondPrc, secondaryInputType, secondInputShape);
+    auto secondPrc = ngraph::element::Type_t::i32;  // according to the specification
+    auto secondaryInput = ngraph::builder::makeConstant(secondPrc, {secondInputShape.size()}, secondInputShape);
     if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
         paramsIn.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(secondaryInput));
     }
@@ -60,8 +60,6 @@ void ReverseSequenceLayerTest::SetUp() {
     function = std::make_shared<ngraph::Function>(results, paramsIn, "ReverseSequence");
 }
 
-TEST_P(ReverseSequenceLayerTest, CompareWithRefs) {
-    Run();
-};
+TEST_P(ReverseSequenceLayerTest, CompareWithRefs) { Run(); };
 
-} // namespace LayerTestsDefinitions
+}  // namespace LayerTestsDefinitions


### PR DESCRIPTION
formerly, The 1D tensor of sequence lengths is made by "makeInputLayer" . it have a attribute InputLayerType, we can configure it in our test case. Normally like those input, we will make it as constant. but in makeInputLayer, makeConstant op will use the zero as input data, it may cause the sequence length overlap. 

so I decide to replace it, if we have gather merge into master, maybe we can change this easily. 