### PR TITLE
Fix ROIPooling, add "constant" tag as input parameter, change data generate border check.

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/roi_pooling.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/roi_pooling.hpp
@@ -24,6 +24,7 @@ using roiPoolingParamsTuple = std::tuple<
         float,                                      // Spatial scale
         ngraph::helpers::ROIPoolingTypes,           // ROIPooling method
         InferenceEngine::Precision,                 // Net precision
+        ngraph::helpers::InputLayerType,            // Secondary input type
         LayerTestsUtils::TargetDevice>;             // Device name
 
 class ROIPoolingLayerTest : public testing::WithParamInterface<roiPoolingParamsTuple>,
@@ -34,9 +35,11 @@ public:
 
 protected:
     void SetUp() override;
+    void GenerateCoords(const std::vector<size_t> &feat_map_shape, float *buffer, size_t size);
 
 private:
     ngraph::helpers::ROIPoolingTypes pool_method;
+    ngraph::helpers::InputLayerType secondaryInputType;
     float spatial_scale;
 };
 

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
@@ -14,8 +14,9 @@ namespace LayerTestsDefinitions {
         float spatial_scale;
         ngraph::helpers::ROIPoolingTypes pool_method;
         InferenceEngine::Precision netPrecision;
+        ngraph::helpers::InputLayerType secondaryInputType;
         std::string targetDevice;
-        std::tie(inputShape, coordsShape, poolShape, spatial_scale, pool_method, netPrecision, targetDevice) = obj.param;
+        std::tie(inputShape, coordsShape, poolShape, spatial_scale, pool_method, netPrecision, secondaryInputType, targetDevice) = obj.param;
 
         std::ostringstream result;
 
@@ -32,36 +33,43 @@ namespace LayerTestsDefinitions {
                 break;
         }
         result << "netPRC=" << netPrecision.name() << "_";
+        result << "secondaryInputType=" << secondaryInputType;
         result << "trgDev=" << targetDevice;
         return result.str();
     }
 
-    void ROIPoolingLayerTest::Infer() {
-        inferRequest = executableNetwork.CreateInferRequest();
-        inputs.clear();
-
-        auto feat_map_shape = cnnNetwork.getInputShapes().begin()->second;
+    void ROIPoolingLayerTest::GenerateCoords(const std::vector<size_t> &feat_map_shape, float *buffer, size_t size) {
         const int height = pool_method == ngraph::helpers::ROIPoolingTypes::ROI_MAX ? feat_map_shape[2] / spatial_scale : 1;
         const int width = pool_method == ngraph::helpers::ROIPoolingTypes::ROI_MAX ? feat_map_shape[3] / spatial_scale : 1;
+        CommonTestUtils::fill_data_roi(buffer, size, feat_map_shape[0] - 1, height, width, 1.0f);
+    }
 
-        size_t it = 0;
-        for (const auto &input : cnnNetwork.getInputsInfo()) {
-            const auto &info = input.second;
-            InferenceEngine::Blob::Ptr blob;
+    void ROIPoolingLayerTest::Infer() {
+        if (secondaryInputType == ngraph::helpers::InputLayerType::CONSTANT) {
+            LayerTestsCommon::Infer();
+        } else if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
+            inferRequest = executableNetwork.CreateInferRequest();
+            inputs.clear();
+            auto feat_map_shape = cnnNetwork.getInputShapes().begin()->second;
 
-            if (it == 1) {
-                blob = make_blob_with_precision(info->getTensorDesc());
-                blob->allocate();
-                CommonTestUtils::fill_data_roi(blob->buffer(), blob->size(), feat_map_shape[0] - 1,
-                                               height, width, 1.0f);
-            } else {
-                blob = GenerateInput(*info);
+            size_t it = 0;
+            for (const auto &input : cnnNetwork.getInputsInfo()) {
+                const auto &info = input.second;
+                InferenceEngine::Blob::Ptr blob;
+
+                if (it == 1) {
+                    blob = make_blob_with_precision(info->getTensorDesc());
+                    blob->allocate();
+                    GenerateCoords(feat_map_shape, blob->buffer(), blob->size());
+                } else {
+                    blob = GenerateInput(*info);
+                }
+                inferRequest.SetBlob(info->name(), blob);
+                inputs.push_back(blob);
+                it++;
             }
-            inferRequest.SetBlob(info->name(), blob);
-            inputs.push_back(blob);
-            it++;
+            inferRequest.Infer();
         }
-        inferRequest.Infer();
     }
 
     void ROIPoolingLayerTest::SetUp() {
@@ -71,14 +79,24 @@ namespace LayerTestsDefinitions {
         InferenceEngine::Precision netPrecision;
         float spatial_scale;
 
-        std::tie(inputShape, coordsShape, poolShape, spatial_scale, pool_method, netPrecision, targetDevice) = this->GetParam();
+        std::tie(inputShape, coordsShape, poolShape, spatial_scale, pool_method, netPrecision, secondaryInputType, targetDevice) = this->GetParam();
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShape, coordsShape});
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         auto paramOuts = ngraph::helpers::convert2OutputVector(
-                ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+        size_t size = 1;
+        for (auto dim : coordsShape){
+            size *= dim;
+        }
+        std::vector<float> coords(size);
+        GenerateCoords(inputShape, coords.data(), size);
+        auto secondaryInput = ngraph::builder::makeInputLayer(ngPrc, secondaryInputType, coordsShape, coords);
+        if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
+            params.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(secondaryInput));
+        }
         std::shared_ptr<ngraph::Node> roi_pooling = ngraph::builder::makeROIPooling(paramOuts[0],
-                                                                                    paramOuts[1],
+                                                                                    secondaryInput,
                                                                                     poolShape,
                                                                                     spatial_scale,
                                                                                     pool_method);

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
@@ -77,7 +77,6 @@ namespace LayerTestsDefinitions {
         InferenceEngine::SizeVector coordsShape;
         InferenceEngine::SizeVector poolShape;
         InferenceEngine::Precision netPrecision;
-        float spatial_scale;
 
         std::tie(inputShape, coordsShape, poolShape, spatial_scale, pool_method, netPrecision, secondaryInputType, targetDevice) = this->GetParam();
 

--- a/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -135,9 +135,9 @@ static void fill_data_roi(float *data, size_t size, const uint32_t range, const 
         if (data[i + 3] < data[i + 1]) {
             std::swap(data[i + 1], data[i + 3]);
         }
-        if (data[i + 1] < 0)
+        if (data[i + 1] < 0 || data[i + 1] > width - 1)
             data[i + 1] = 0;
-        if (data[i + 3] > width - 1)
+        if (data[i + 3] > width - 1 || data[i + 3] < 0)
             data[i + 3] = static_cast<float>(width - 1);
 
         data[i + 2] = std::floor(center_h + height * 0.6f * sin(static_cast<float>(i+2) * omega));
@@ -145,9 +145,9 @@ static void fill_data_roi(float *data, size_t size, const uint32_t range, const 
         if (data[i + 4] < data[i + 2]) {
             std::swap(data[i + 2], data[i + 4]);
         }
-        if (data[i + 2] < 0)
+        if (data[i + 2] < 0 || data[i + 2] > height - 1)
             data[i + 2] = 0;
-        if (data[i + 4] > height - 1)
+        if (data[i + 4] > height - 1 || data[i + 4] < 0)
             data[i + 4] = static_cast<float>(height - 1);
     }
 }

--- a/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -135,19 +135,27 @@ static void fill_data_roi(float *data, size_t size, const uint32_t range, const 
         if (data[i + 3] < data[i + 1]) {
             std::swap(data[i + 1], data[i + 3]);
         }
-        if (data[i + 1] < 0 || data[i + 1] > width - 1)
+        if (data[i + 1] < 0)
             data[i + 1] = 0;
-        if (data[i + 3] > width - 1 || data[i + 3] < 0)
+        if (data[i + 1] > width - 1)
+            data[i + 1] = static_cast<float>(width - 1);
+        if (data[i + 3] < 0)
+            data[i + 3] = 0;
+        if (data[i + 3] > width - 1)
             data[i + 3] = static_cast<float>(width - 1);
 
-        data[i + 2] = std::floor(center_h + height * 0.6f * sin(static_cast<float>(i+2) * omega));
-        data[i + 4] = std::floor(center_h + height * 0.6f * sin(static_cast<float>(i+4) * omega));
+        data[i + 2] = std::floor(center_h + height * 0.6f * sin(static_cast<float>(i + 2) * omega));
+        data[i + 4] = std::floor(center_h + height * 0.6f * sin(static_cast<float>(i + 4) * omega));
         if (data[i + 4] < data[i + 2]) {
             std::swap(data[i + 2], data[i + 4]);
         }
-        if (data[i + 2] < 0 || data[i + 2] > height - 1)
+        if (data[i + 2] < 0)
             data[i + 2] = 0;
-        if (data[i + 4] > height - 1 || data[i + 4] < 0)
+        if (data[i + 2] > height - 1)
+            data[i + 2] = static_cast<float>(height - 1);
+        if (data[i + 4] < 0)
+            data[i + 4] = 0;
+        if (data[i + 4] > height - 1)
             data[i + 4] = static_cast<float>(height - 1);
     }
 }

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -67,6 +67,24 @@ std::shared_ptr<Node> makeConstant(const element::Type &type, const std::vector<
     return weightsNode;
 }
 
+template <typename T>
+std::shared_ptr<ngraph::Node> makeInputLayer(const element::Type &type, ngraph::helpers::InputLayerType inputType,
+                                             const std::vector<size_t> &shape, const std::vector<T> &data) {
+    std::shared_ptr<ngraph::Node> input;
+    switch (inputType) {
+        case ngraph::helpers::InputLayerType::CONSTANT: {
+            input = ngraph::builder::makeConstant<T>(type, shape, data, false);
+            break;
+        }
+        case ngraph::helpers::InputLayerType::PARAMETER:
+            input = ngraph::builder::makeParams(type, {shape})[0];
+            break;
+        default:
+            throw std::runtime_error("Unsupported inputType");
+    }
+    return input;
+}
+
 std::shared_ptr<ngraph::Node> makeInputLayer(const element::Type& type, ngraph::helpers::InputLayerType inputType,
                                              const std::vector<size_t>& shape);
 


### PR DESCRIPTION
Add `ngraph::helpers::InputLayerType` in `roiPoolingParamsTuple`, we can use it to decide that `coordinate` parameter be treated as `constant` node or `parameter` node.
and adjust the `ROIPoolingLayerTest` class, let `constant` and `parameter` to be filled by same data.
modify `fill_data_roi`, it shouldn't have negative number in `coordinate` parameter. 